### PR TITLE
trips-for-location fails when no trip linked to vehicle

### DIFF
--- a/otp-core/src/main/java/org/opentripplanner/api/ws/oba_rest_api/methods/TripsForLocationMethod.java
+++ b/otp-core/src/main/java/org/opentripplanner/api/ws/oba_rest_api/methods/TripsForLocationMethod.java
@@ -75,11 +75,14 @@ public class TripsForLocationMethod extends OneBusAwayApiMethod<TransitListEntry
         
         List<TransitTripDetails> tripDetails = new ArrayList<TransitTripDetails>(vehicles.size());
         for(VehicleLocation vehicle : vehicles) {
-            TransitTripDetails tripDetail = getTripDetails(vehicle.getTripId(), vehicle.getServiceDate(),
-                    includeStatus, includeSchedules, includeTrips);
-            
-            if(tripDetail != null) {
-                tripDetails.add(tripDetail);
+            AgencyAndId tripId = vehicle.getTripId();
+            if (tripId != null) {
+                TransitTripDetails tripDetail = getTripDetails(tripId, vehicle.getServiceDate(),
+                        includeStatus, includeSchedules, includeTrips);
+                
+                if(tripDetail != null) {
+                    tripDetails.add(tripDetail);
+                }
             }
         }
         


### PR DESCRIPTION
The trips-for-location API method throwed a NullPointerException when there was no trip linked to the vehicle.
